### PR TITLE
Update EmailParser URL handling

### DIFF
--- a/src/app/viewer/msg/page.tsx
+++ b/src/app/viewer/msg/page.tsx
@@ -14,7 +14,7 @@ export default async function ViewerPage(props: {
 
   return (
     <Suspense fallback={<LoaderView />}>
-      <EmailParser url={decodeURIComponent(rawUrl)} type="msg" />
+      <EmailParser url={rawUrl} type="msg" />
     </Suspense>
   );
 }


### PR DESCRIPTION
## Summary
- pass raw URL to EmailParser in msg viewer
- avoid double-decoding in ViewerPage

## Test plan
- [ ] Verify msg viewer loads email with encoded URL

Made with [Cursor](https://cursor.com)